### PR TITLE
Fix parameterize to rails 5

### DIFF
--- a/lib/tagify_string/core_ext.rb
+++ b/lib/tagify_string/core_ext.rb
@@ -31,18 +31,18 @@ String.class_eval do
     else
       output = self.gsub("_", " ").gsub("'", "").parameterize(opts[:sep])
     end
-    
+
     return "" if output.length == 0
 
     # Otherwise, attach prefix, process for case and send back.
     if prefix.present?
       if Rails::VERSION::MAJOR >= 5
-        output = [prefix, output].join(" ").parameterize(separator: opts[:sep]) if prefix.present?  
+        output = [prefix, output].join(" ").parameterize(separator: opts[:sep])
       else
-        output = [prefix, output].join(" ").parameterize(opts[:sep]) if prefix.present?
+        output = [prefix, output].join(" ").parameterize(opts[:sep])
       end
     end
-    
+
     opts[:upcase] ? output.upcase : output.downcase
   end
 

--- a/lib/tagify_string/core_ext.rb
+++ b/lib/tagify_string/core_ext.rb
@@ -26,8 +26,6 @@ String.class_eval do
     end
 
     # The Sonia Clause.  Check for all garbage characters.  Return an empty string in this case.
-    output = ""
-
     if Rails::VERSION::MAJOR >= 5
       output = self.gsub("_", " ").gsub("'", "").parameterize(separator: opts[:sep])
     else
@@ -37,12 +35,14 @@ String.class_eval do
     return "" if output.length == 0
 
     # Otherwise, attach prefix, process for case and send back.
-    if Rails::VERSION::MAJOR >= 5
-      output = [prefix, output].join(" ").parameterize(separator: opts[:sep]) if prefix.present?  
-    else
-      output = [prefix, output].join(" ").parameterize(opts[:sep]) if prefix.present?
+    if prefix.present?
+      if Rails::VERSION::MAJOR >= 5
+        output = [prefix, output].join(" ").parameterize(separator: opts[:sep]) if prefix.present?  
+      else
+        output = [prefix, output].join(" ").parameterize(opts[:sep]) if prefix.present?
+      end
     end
-
+    
     opts[:upcase] ? output.upcase : output.downcase
   end
 

--- a/lib/tagify_string/core_ext.rb
+++ b/lib/tagify_string/core_ext.rb
@@ -26,11 +26,22 @@ String.class_eval do
     end
 
     # The Sonia Clause.  Check for all garbage characters.  Return an empty string in this case.
-    output = self.gsub("_", " ").gsub("'", "").parameterize(opts[:sep])
+    output = ""
+
+    if Rails::VERSION::MAJOR >= 5
+      output = self.gsub("_", " ").gsub("'", "").parameterize(separator: opts[:sep])
+    else
+      output = self.gsub("_", " ").gsub("'", "").parameterize(opts[:sep])
+    end
+    
     return "" if output.length == 0
 
     # Otherwise, attach prefix, process for case and send back.
-    output = [prefix, output].join(" ").parameterize(opts[:sep]) if prefix.present?
+    if Rails::VERSION::MAJOR >= 5
+      output = [prefix, output].join(" ").parameterize(separator: opts[:sep]) if prefix.present?  
+    else
+      output = [prefix, output].join(" ").parameterize(opts[:sep]) if prefix.present?
+    end
 
     opts[:upcase] ? output.upcase : output.downcase
   end


### PR DESCRIPTION
More info, here: http://api.rubyonrails.org/classes/String.html#method-i-parameterize

On Rails 5, the method was updated. 'parameterize' was throwing wrong number of arguments exception.